### PR TITLE
[TJFE-127] feat: 전체 여행 일지 및 플레이스 목록 API 적용

### DIFF
--- a/TravelJournalForEveryone/TravelJournalForEveryone/Data/Network/API/MembersAPI.swift
+++ b/TravelJournalForEveryone/TravelJournalForEveryone/Data/Network/API/MembersAPI.swift
@@ -24,9 +24,17 @@ extension MembersAPI: EndPoint {
         case .fetchUser(let memberID):
             return "/\(memberID)"
         case .fetchJournals(let request):
-            return "/\(request.memberID)/journals/region/\(request.regionName)"
+            if let regionName = request.regionName {
+                return "/\(request.memberID)/journals/region/\(regionName)"
+            } else {
+                return "/\(request.memberID)/journals"
+            }
         case .fetchPlaces(let request):
-            return "/\(request.memberID)/places/region/\(request.regionName)"
+            if let regionName = request.regionName {
+                return "/\(request.memberID)/places/region/\(regionName)"
+            } else {
+                return "/\(request.memberID)/places"
+            }
         }
     }
     

--- a/TravelJournalForEveryone/TravelJournalForEveryone/Data/Network/DTO/Members/FetchJournalsRequest.swift
+++ b/TravelJournalForEveryone/TravelJournalForEveryone/Data/Network/DTO/Members/FetchJournalsRequest.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct FetchJournalsRequest {
     let memberID: Int
-    let regionName: String
+    let regionName: String?
     let pageNumber: Int
     let pageSize: Int
 }

--- a/TravelJournalForEveryone/TravelJournalForEveryone/Data/Network/DTO/Members/FetchPlacesRequest.swift
+++ b/TravelJournalForEveryone/TravelJournalForEveryone/Data/Network/DTO/Members/FetchPlacesRequest.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct FetchPlacesRequest {
     let memberID: Int
-    let regionName: String
+    let regionName: String?
     let pageNumber: Int
     let pageSize: Int
 }

--- a/TravelJournalForEveryone/TravelJournalForEveryone/Data/Repositories/DefaultJournalRepository.swift
+++ b/TravelJournalForEveryone/TravelJournalForEveryone/Data/Repositories/DefaultJournalRepository.swift
@@ -17,7 +17,7 @@ final class DefaultJournalRepository: JournalRepository {
     
     func fetchJournals(
         memberID: Int,
-        regionName: String,
+        regionName: String?,
         pageNumber: Int,
         pageSize: Int
     ) -> AnyPublisher<Pageable<JournalSummary>, NetworkError> {

--- a/TravelJournalForEveryone/TravelJournalForEveryone/Data/Repositories/DefaultPlaceRepository.swift
+++ b/TravelJournalForEveryone/TravelJournalForEveryone/Data/Repositories/DefaultPlaceRepository.swift
@@ -17,7 +17,7 @@ final class DefaultPlaceRepository: PlaceRepository {
     
     func fetchPlaces(
         memberID: Int,
-        regionName: String,
+        regionName: String?,
         pageNumber: Int,
         pageSize: Int
     ) -> AnyPublisher<Pageable<PlaceSummary>, NetworkError> {

--- a/TravelJournalForEveryone/TravelJournalForEveryone/Domain/Interfaces/JournalRepository.swift
+++ b/TravelJournalForEveryone/TravelJournalForEveryone/Domain/Interfaces/JournalRepository.swift
@@ -11,7 +11,7 @@ import Combine
 protocol JournalRepository {
     func fetchJournals(
         memberID: Int,
-        regionName: String,
+        regionName: String?,
         pageNumber: Int,
         pageSize: Int
     ) -> AnyPublisher<Pageable<JournalSummary>, NetworkError>

--- a/TravelJournalForEveryone/TravelJournalForEveryone/Domain/Interfaces/PlaceRepository.swift
+++ b/TravelJournalForEveryone/TravelJournalForEveryone/Domain/Interfaces/PlaceRepository.swift
@@ -11,7 +11,7 @@ import Combine
 protocol PlaceRepository {
     func fetchPlaces(
         memberID: Int,
-        regionName: String,
+        regionName: String?,
         pageNumber: Int,
         pageSize: Int
     ) -> AnyPublisher<Pageable<PlaceSummary>, NetworkError>

--- a/TravelJournalForEveryone/TravelJournalForEveryone/Domain/UseCases/FetchJournalsUseCase.swift
+++ b/TravelJournalForEveryone/TravelJournalForEveryone/Domain/UseCases/FetchJournalsUseCase.swift
@@ -11,7 +11,7 @@ import Combine
 protocol FetchJournalsUseCase {
     func execute(
         memberID: Int?,
-        regionName: String,
+        regionName: String?,
         pageNumber: Int
     ) -> AnyPublisher<Pageable<JournalSummary>, NetworkError>
 }
@@ -27,11 +27,12 @@ struct DefaultFetchJournalsUseCase: FetchJournalsUseCase {
     /// - Parameters:
     ///   - memberID: 특정 여행자의 정보를 가져오려면 값을 넣어주고,
     ///   nil을 입력하면 현재 로그인된 여행자 기준.
-    ///   - regionName: 지역 이름
+    ///   - regionName: 특정 지역의 정보를 가져오려면 값을 넣어주고,
+    ///   nil을 입력하면 전 지역의 정보를 가져옵니다.
     ///   - pageNumber: 페이지 번호
     func execute(
         memberID: Int?,
-        regionName: String,
+        regionName: String?,
         pageNumber: Int
     ) -> AnyPublisher<Pageable<JournalSummary>, NetworkError> {
         return journalRepository.fetchJournals(

--- a/TravelJournalForEveryone/TravelJournalForEveryone/Domain/UseCases/FetchPlacesUseCase.swift
+++ b/TravelJournalForEveryone/TravelJournalForEveryone/Domain/UseCases/FetchPlacesUseCase.swift
@@ -11,7 +11,7 @@ import Combine
 protocol FetchPlacesUseCase {
     func execute(
         memberID: Int?,
-        regionName: String,
+        regionName: String?,
         pageNumber: Int
     ) -> AnyPublisher<Pageable<PlaceSummary>, NetworkError>
 }
@@ -27,11 +27,12 @@ struct DefaultFetchPlacesUseCase: FetchPlacesUseCase {
     /// - Parameters:
     ///   - memberID: 특정 여행자의 정보를 가져오려면 값을 넣어주고,
     ///   nil을 입력하면 현재 로그인된 여행자 기준.
-    ///   - regionName: 지역 이름
+    ///   - regionName: 특정 지역의 정보를 가져오려면 값을 넣어주고,
+    ///   nil을 입력하면 전 지역의 정보를 가져옵니다.
     ///   - pageNumber: 페이지 번호
     func execute(
         memberID: Int?,
-        regionName: String,
+        regionName: String?,
         pageNumber: Int
     ) -> AnyPublisher<Pageable<PlaceSummary>, NetworkError> {
         return placeRepository.fetchPlaces(

--- a/TravelJournalForEveryone/TravelJournalForEveryone/Presentation/General/JournalPlaceListViewModel.swift
+++ b/TravelJournalForEveryone/TravelJournalForEveryone/Presentation/General/JournalPlaceListViewModel.swift
@@ -15,7 +15,7 @@ final class JournalPlaceListViewModel: ObservableObject {
     private let fetchPlacesUseCase: FetchPlacesUseCase
     
     private let user: User
-    private var regionName: String = ""
+    private var regionName: String? = ""
     private var currentJournalsPageNumber: Int = 0
     private var currentPlacesPageNumber: Int = 0
     
@@ -79,22 +79,6 @@ extension JournalPlaceListViewModel {
 }
 
 extension JournalPlaceListViewModel {
-//    private func handlePlaceGridViewOnAppear() {
-//        // TEST - onAppear 될 때마다 API 통신되는 지 추후 확인하기.
-//        self.state.placeSummaries = [
-//            .mock(id: 0, placeName: "이기대 해안산책로"),
-//            .mock(id: 1, placeName: "해운대 해변열차"),
-//            .mock(id: 2, placeName: "웨이브온 커피"),
-//            .mock(id: 3, placeName: "해운대 더베이"),
-//            .mock(id: 4, placeName: "은계 호수공원"),
-//            .mock(id: 5, placeName: "이기대 해안산"),
-//            .mock(id: 6, placeName: "해운대 해변"),
-//            .mock(id: 7, placeName: "웨이브온"),
-//            .mock(id: 8, placeName: "해운대 더베"),
-//            .mock(id: 9, placeName: "은계 호수"),
-//        ]
-//    }
-    
     private func handleSelectSegment(_ index: Int) {
         self.state.selectedSegmentIndex = index
         
@@ -218,10 +202,12 @@ extension JournalPlaceListViewModel {
     
     private func updateRegionName() {
         switch self.state.viewType {
-        case .all, .save, .like:
-            break
+        case .all:
+            self.regionName = nil
         case .region(let region):
             self.regionName = region.rawValue
+        case .save, .like:
+            break
         }
     }
 }


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 여행자의 전체 여행 일지 및 플레이스 목록을 불러옵니다.
- 해당 브랜치에서 전체 여행 일지만 적용하려 했으나, 생각보다 간단해서 전체 플레이스 API 도 적용하였습니다.
<br>

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br>

## 📸스크린샷
생략합니다.

<br>

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- FetchJournalsUseCase의 execute 메서드에서 옵셔널 파라미터를 사용할까, 메서드 오버로딩을 할까 고민을 많이 했습니다. 메서드 오버로딩을 시도해보았으나, 뷰모델에서 사용할 때 분기처리 마다 각각의 다른 메서드를 사용해줘야 하기 때문에 오히려 가독성이 떨어지더라구요... 그래서 기존 방식대로 주석을 사용하고 옵셔널 파라미터를 사용하는 방식으로 진행하였습니다.

- 불러오는 데이터가 많아지다 보니 여행 일지 & 플레이스 좌우 탭을 스크롤 하여 넘길 때 아래 사진처럼 중간에 멈춰버리는 현상이 있습니다. 다음 브랜치에서 확인해보고 수정해보도록 하겠습니다!
![IMG_2541](https://github.com/user-attachments/assets/a326ff2c-5ca9-4f87-b92f-2341306b00d1)



<br>

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
